### PR TITLE
refactored qei to be simpler

### DIFF
--- a/hardwareIO.h
+++ b/hardwareIO.h
@@ -1,6 +1,13 @@
 #ifndef HARDWAREIO_H_
 #define HARDWAREIO_H_
 
+#include <stdint.h>
+
+#define QEI_1_A BIT4
+#define QEI_1_B BIT5
+#define QEI_2_A BIT6
+#define QEI_2_B BIT7
+
 /**
  * init_encoders will initialize hardware to read QEI encoders.
  *
@@ -9,19 +16,6 @@
  * @param[in] count_b integer pointer that should be updated from hardware interrupts for secondary encoder
  * if pointer is 0 then do not initialize encoder.
  */
-void init_encoders(unsigned int* count_a, unsigned int* count_b);
-
-/**
- * init_switches will initialize hardware interrupts to read limit switches or buttons.
- *
- * @param[in] switch_a is the callback function that will be invoked when the limit switch connected to pin
- * 2.4 on the micro-controller is triggered.
- *
- * @param[in] switch_b is the callback function that will be invoked when the limit switch connected to pin
- * 2.5 on the micro-controller is triggered.
- *
- * if either parameter is null do not initialize hardware for the associated pin.
- */
-void init_switches(void(*switch_a)(int), void(*switch_b)(int));
+void init_encoders(uint8_t* memory_map);
 
 #endif /* HARDWARE_H_ */

--- a/remex.c
+++ b/remex.c
@@ -35,6 +35,7 @@ void init(void)
     init_adc((uint8_t*)&regmap);
     init_pwm_A();
     init_pwm_B();
+    init_encoders((uint8_t*)&regmap);
     i2c_slave_init(SLAVE_ADDR, (uint8_t*)&regmap);
 
     __bis_SR_register(GIE); // Enable global interrupts
@@ -72,20 +73,6 @@ void start_motors() {
 
     int pwm_speed_b = BYTES_TO_SHORT(regmap, DES_SPEED_B);
     set_pwm_B(pwm_speed_b);
-}
-
-// This function is called in an interrupt. Do not stall.
-void process_i2c_command(const uint8_t command)
-{
-    // goto/begin command
-    switch(command) {
-    case 0xa5:
-        P6OUT |= BIT6;
-        break;
-    case 0x2E:
-        P6OUT &=~ BIT6;
-        break;
-    }
 }
 
 void clear_registers(void)


### PR DESCRIPTION
- Removed complicated call back functions that made things difficult to read.
- Also removed extra pointers referencing specific locations in the memory map and treating them as ints. Instead just used the macros in the i2c.h file to load encoder values into the memory map.
- Removed the complicated code for limit switches. This software is primarily for the dual motor tracks remex and it does not need limit switches. 
- Removed the process command function from the remex.c file. 